### PR TITLE
fix: ensure transpilePackages includes necessary dependencies

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
   output: "standalone",
   reactStrictMode: true,
   serverExternalPackages: ["@aws-sdk/s3-request-presigner"],
+  transpilePackages: ["@t3-oss/env-nextjs", "@t3-oss/env-core"],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
This pull request includes a small change to the `next.config.mjs` file. The change adds two packages, `@t3-oss/env-nextjs` and `@t3-oss/env-core`, to the `transpilePackages` configuration to ensure they are transpiled during the build process.